### PR TITLE
added uuids to tables for future proofing - might want to move cutsom…

### DIFF
--- a/app/types/customerTypes.ts
+++ b/app/types/customerTypes.ts
@@ -1,20 +1,21 @@
 // For form request data coming from fronend when submitting invoice related data
 
 type CustomerRequestData = {
+  customerUUID: string,
   customerId: number,
-    firstName: string,
-    lastName: string,
-    phoneNo: string,
-    email: string,    
-    companyName: string,
-    unitNo: number,
-    street: string,
-    city: string
-    postalCode: string,
-    state: string,
-    country: string,
-    notes: string,
-    isActive: boolean
+  firstName: string,
+  lastName: string,
+  phoneNo: string,
+  email: string,    
+  companyName: string,
+  unitNo: number,
+  street: string,
+  city: string
+  postalCode: string,
+  state: string,
+  country: string,
+  notes: string,
+  isActive: boolean
   }
 
 type CustomerDetails = {

--- a/drizzle/database/seed.ts
+++ b/drizzle/database/seed.ts
@@ -11,7 +11,7 @@
     Then run,
 
     ```
-      yarn seed
+      yarn seed-db
     ```
 
     The way I currently sseded the data was converting this file into a .cjs file, change "type":"commonjs" 
@@ -40,11 +40,11 @@ async function seedDB() {
           companyName: 'Doe Enterprises',
           unitNo: '101',
           street: '123 Main St',
-          city: 'New York',
-          postalCode: '10001',
-          state: 'NY',
-          country: 'USA',
-          phoneNo: '+1 123 456 7890',
+          city: 'Toronto',
+          postalCode: 'M5H 2N2',
+          state: 'ON',
+          country: 'Canada',
+          phoneNo: '+14164567890',
           isActive: true, // Explicitly setting active status
         },
         {
@@ -54,11 +54,11 @@ async function seedDB() {
           companyName: 'Smith Solutions',
           unitNo: '202A',
           street: '456 Elm St',
-          city: 'San Francisco',
-          postalCode: '94016',
-          state: 'CA',
-          country: 'USA',
-          phoneNo: '+1 987 654 3210',
+          city: 'Vancouver',
+          postalCode: 'V6B 4N8',
+          state: 'BC',
+          country: 'Canada',
+          phoneNo: '+16046543210',
           isActive: true,
         },
         {
@@ -67,22 +67,22 @@ async function seedDB() {
           email: 'alice.johnson@example.com',
           companyName: 'Alice Corp',
           street: '789 Oak St',
-          city: 'Los Angeles',
-          postalCode: '90001',
-          state: 'CA',
-          country: 'USA',
-          phoneNo: '+1 555 123 4567',
+          city: 'Montreal',
+          postalCode: 'H3B 1A7',
+          state: 'QC',
+          country: 'Canada',
+          phoneNo: '+15141234567',
           isActive: false,
         },
       ])
-      .returning({ customerId: Customer.customerId });
+      .returning({ customerUUID: Customer.customerUUID });
 
-    const customerIds = insertedCustomer.map((customer) => customer.customerId);
+    const customerUUIDs = insertedCustomer.map((customer) => customer.customerUUID);
 
     // Create fake invoices with all required fields
     const invoices = await db.insert(Invoices).values([
       {
-        customerId: customerIds[0],
+        customerUUID: customerUUIDs[0],
         invoiceNumber: 'INV-001',
         amount: '150.00',
         amountPaid: '0.00',
@@ -91,27 +91,45 @@ async function seedDB() {
         invoiceDate: new Date().toISOString().split('T')[0], // YYYY-MM-DD
       },
       {
-        customerId: customerIds[1],
+        customerUUID: customerUUIDs[0],
         invoiceNumber: 'INV-002',
+        amount: '150.00',
+        amountPaid: '150.00',
+        invoiceStatus: InvoiceStatus.Paid,
+
+        invoiceDate: new Date().toISOString().split('T')[0], // YYYY-MM-DD
+      },
+      {
+        customerUUID: customerUUIDs[1],
+        invoiceNumber: 'INV-003',
         amount: '200.00',
         amountPaid: '200.00',
         invoiceStatus: InvoiceStatus.Paid,
         invoiceDate: new Date().toISOString().split('T')[0],
       },
       {
-        customerId: customerIds[1],
-        invoiceNumber: 'INV-003',
+        customerUUID: customerUUIDs[1],
+        invoiceNumber: 'INV-004',
         amount: '250.00',
         amountPaid: '0.00',
         invoiceStatus: InvoiceStatus.Unpaid,
         invoiceDate: new Date().toISOString().split('T')[0],
       },
       {
-        customerId: customerIds[2],
-        invoiceNumber: 'INV-004',
+        customerUUID: customerUUIDs[2],
+        invoiceNumber: 'INV-005',
         amount: '300.00',
         amountPaid: '0.00',
         invoiceStatus: InvoiceStatus.Unpaid,
+        invoiceDate: new Date().toISOString().split('T')[0],
+        isArchived: true,
+      },
+      {
+        customerUUID: customerUUIDs[2],
+        invoiceNumber: 'INV-006',
+        amount: '100.00',
+        amountPaid: '100.00',
+        invoiceStatus: InvoiceStatus.Paid,
         invoiceDate: new Date().toISOString().split('T')[0],
         isArchived: true,
       },

--- a/drizzle/migrations/0002_UUID_Column_Customer_invoice_InvoiceDocuments_Tables.sql
+++ b/drizzle/migrations/0002_UUID_Column_Customer_invoice_InvoiceDocuments_Tables.sql
@@ -1,0 +1,46 @@
+ALTER TABLE "invoice_documents" DROP CONSTRAINT "invoice_documents_invoice_id_invoices_invoice_id_fk";
+--> statement-breakpoint
+ALTER TABLE "invoices" DROP CONSTRAINT "invoices_customer_id_customers_customer_id_fk";
+--> statement-breakpoint
+/* 
+    Unfortunately in current drizzle-kit version we can't automatically get name for primary key.
+    We are working on making it available!
+
+    Meanwhile you can:
+        1. Check pk name in your database, by running
+            SELECT constraint_name FROM information_schema.table_constraints
+            WHERE table_schema = 'public'
+                AND table_name = 'customers'
+                AND constraint_type = 'PRIMARY KEY';
+        2. Uncomment code below and paste pk name manually
+        
+    Hope to release this update as soon as possible
+*/
+
+-- ALTER TABLE "customers" DROP CONSTRAINT "<constraint_name>";--> statement-breakpoint
+/* 
+    Unfortunately in current drizzle-kit version we can't automatically get name for primary key.
+    We are working on making it available!
+
+    Meanwhile you can:
+        1. Check pk name in your database, by running
+            SELECT constraint_name FROM information_schema.table_constraints
+            WHERE table_schema = 'public'
+                AND table_name = 'invoices'
+                AND constraint_type = 'PRIMARY KEY';
+        2. Uncomment code below and paste pk name manually
+        
+    Hope to release this update as soon as possible
+*/
+
+-- ALTER TABLE "invoices" DROP CONSTRAINT "<constraint_name>";--> statement-breakpoint
+ALTER TABLE "customers" ADD COLUMN "customer_uuid" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL;--> statement-breakpoint
+ALTER TABLE "invoice_documents" ADD COLUMN "invoice_uuid" uuid NOT NULL;--> statement-breakpoint
+ALTER TABLE "invoices" ADD COLUMN "invoice_uuid" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL;--> statement-breakpoint
+ALTER TABLE "invoices" ADD COLUMN "customer_uuid" uuid NOT NULL;--> statement-breakpoint
+ALTER TABLE "invoice_documents" ADD CONSTRAINT "invoice_documents_invoice_uuid_invoices_invoice_uuid_fk" FOREIGN KEY ("invoice_uuid") REFERENCES "public"."invoices"("invoice_uuid") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoices" ADD CONSTRAINT "invoices_customer_uuid_customers_customer_uuid_fk" FOREIGN KEY ("customer_uuid") REFERENCES "public"."customers"("customer_uuid") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoice_documents" DROP COLUMN "invoice_id";--> statement-breakpoint
+ALTER TABLE "invoices" DROP COLUMN "customer_id";--> statement-breakpoint
+ALTER TABLE "customers" ADD CONSTRAINT "customers_customer_id_unique" UNIQUE("customer_id");--> statement-breakpoint
+ALTER TABLE "invoices" ADD CONSTRAINT "invoices_invoice_id_unique" UNIQUE("invoice_id");

--- a/drizzle/migrations/meta/0002_snapshot.json
+++ b/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,341 @@
+{
+  "id": "b5fe47b1-0a68-4747-afbe-c0ba2ddbfd49",
+  "prevId": "4a5c1913-36bf-4c0c-b0ab-b56e987a3871",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "customer_uuid": {
+          "name": "customer_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(355)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_no": {
+          "name": "unit_no",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customers_customer_id_unique": {
+          "name": "customers_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "customer_id"
+          ]
+        },
+        "customers_phone_number_unique": {
+          "name": "customers_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        },
+        "customers_email_unique": {
+          "name": "customers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "customers_company_name_unique": {
+          "name": "customers_company_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "company_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_documents": {
+      "name": "invoice_documents",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_uuid": {
+          "name": "invoice_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_date": {
+          "name": "upload_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_documents_invoice_uuid_invoices_invoice_uuid_fk": {
+          "name": "invoice_documents_invoice_uuid_invoices_invoice_uuid_fk",
+          "tableFrom": "invoice_documents",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_uuid"
+          ],
+          "columnsTo": [
+            "invoice_uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_documents_file_name_unique": {
+          "name": "invoice_documents_file_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_name"
+          ]
+        },
+        "invoice_documents_file_path_unique": {
+          "name": "invoice_documents_file_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "invoice_uuid": {
+          "name": "invoice_uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_uuid": {
+          "name": "customer_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "invoice_date": {
+          "name": "invoice_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invoice_status": {
+          "name": "invoice_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unpaid'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_customer_uuid_customers_customer_uuid_fk": {
+          "name": "invoices_customer_uuid_customers_customer_uuid_fk",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_uuid"
+          ],
+          "columnsTo": [
+            "customer_uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_id_unique": {
+          "name": "invoices_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_id"
+          ]
+        },
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1739993733121,
       "tag": "0001_Updated_Invoices_Column_Name",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1741552895440,
+      "tag": "0002_UUID_Column_Customer_invoice_InvoiceDocuments_Tables",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Added the UUID for future proofing. Specifically, that if i add a table to separate inactive customers from active or have an archived table table instead (that would hold inactive customer from over 1 year), then moving them along with their invoices is easily done. Using a UUID lets us keep a stable reference between cutomer and their invoice objects

I know UUID could affect the db performance, BUT the number of times this operation of moving objects is going to be very minimal if done at all. Thus, using uuid is a justifiable approach here

For now I am implementing a soft delete. If need be could partition the tables using a List Partition into active and inactive vertical partitions. This could improve querying